### PR TITLE
Support module self type

### DIFF
--- a/.github/workflows/steep.yml
+++ b/.github/workflows/steep.yml
@@ -1,4 +1,4 @@
-name: Main
+name: Steep
 
 on:
   push:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,8 @@ AllCops:
 
 Lint:
   Enabled: true
+Lint/EmptyBlock:
+  Enabled: false
 
 Style:
   Enabled: false

--- a/lib/raap/cli.rb
+++ b/lib/raap/cli.rb
@@ -16,6 +16,7 @@ module RaaP
       keyword_init: true
     )
 
+    # Should skip methods has side effects
     DEFAULT_SKIP = Set.new
     %i[
       fork system exec spawn `

--- a/lib/raap/type.rb
+++ b/lib/raap/type.rb
@@ -195,7 +195,7 @@ module RaaP
           raise
         end
       else
-        [:call, Value::Module, :new, [type.to_s], {}, nil]
+        [:call, Value::Module, :new, [type.to_s], { size: }, nil]
       end
     end
 
@@ -336,7 +336,7 @@ module RaaP
     def temp_method_object
       o = Object.new
       m = 6.times.map { SIMPLE_SOURCE.sample }.join
-      o.define_singleton_method(m) {} # rubocop:disable Lint/EmptyBlock
+      o.define_singleton_method(m) {}
       o.method(m)
     end
   end

--- a/lib/raap/value/interface.rb
+++ b/lib/raap/value/interface.rb
@@ -10,10 +10,10 @@ module RaaP
         end
         @size = size
 
-        definition = RBS.builder.build_interface(@type.name.absolute!)
-        definition.methods.each do |name, method|
+        @definition = RBS.builder.build_interface(@type.name.absolute!)
+        @definition.methods.each do |name, method|
           method_type = method.method_types.sample or Kernel.raise
-          type_params = definition.type_params_decl.concat(method_type.type_params.drop(definition.type_params_decl.length))
+          type_params = @definition.type_params_decl.concat(method_type.type_params.drop(@definition.type_params_decl.length))
           ts = TypeSubstitution.new(type_params, @type.args)
 
           subed_method_type = ts.method_type_sub(method_type, self_type:, instance_type:, class_type:)
@@ -42,12 +42,16 @@ module RaaP
         end
       end
 
+      def respond_to?(name, _include_all = false)
+        @definition.methods.has_key?(name.to_sym)
+      end
+
       def class
         Interface
       end
 
       def inspect
-        "#<interface @type=#{@type} @methods=#{RBS.builder.build_interface(@type.name.absolute!).methods.keys} @size=#{@size}>"
+        "#<interface @type=#{@type} @methods=#{@definition.methods.keys} @size=#{@size}>"
       end
     end
   end

--- a/lib/raap/value/intersection.rb
+++ b/lib/raap/value/intersection.rb
@@ -21,21 +21,26 @@ module RaaP
       end
 
       def method_missing(name, *args, **kwargs, &block)
-        @children.each do |child|
-          if BindCall.respond_to?(child, name)
-            return child.__send__(name, *args, **kwargs, &block)
+        if respond_to?(name)
+          @children.each do |child|
+            if BindCall.respond_to?(child, name)
+              return child.__send__(name, *args, **kwargs, &block)
+            end
           end
+          ::Kernel.raise
+        else
+          super
         end
-
-        super
       end
 
       def respond_to?(name, include_all = false)
-        @children.any? do |type|
-          BindCall.respond_to?(type, name, include_all)
+        @children.any? do |child|
+          if BindCall.instance_of?(child, ::BasicObject)
+            BindCall.respond_to?(child, name, include_all)
+          else
+            child.respond_to?(name, include_all)
+          end
         end
-
-        super
       end
     end
   end

--- a/lib/raap/value/module.rb
+++ b/lib/raap/value/module.rb
@@ -2,20 +2,52 @@ module RaaP
   module Value
     # FIXME: consider self_types
     # HINT: intersection?
-    class Module
-      attr_reader :type
-
-      def initialize(type)
-        @type = type.is_a?(String) ? RBS.parse_type(type) : type
+    class Module < BasicObject
+      def initialize(type, size: 3)
+        @type = type.is_a?(::String) ? ::RaaP::RBS.parse_type(type) : type
+        @size = size
         unless @type.instance_of?(::RBS::Types::ClassInstance)
-          raise ::TypeError, "not a module type: #{@type}"
+          ::Kernel.raise ::TypeError, "not a module type: #{@type}"
         end
 
+        one_instance_ancestors = ::RaaP::RBS.builder.ancestor_builder.one_instance_ancestors(@type.name.absolute!).self_types
+        @self_type = if one_instance_ancestors.nil? || one_instance_ancestors.empty?
+                       ::Object.new
+                     else
+                       a_instance = one_instance_ancestors.first or ::Kernel.raise
+                       if a_instance.args.empty?
+                         # : BasicObject
+                         Type.new(a_instance.name.to_s).pick(size:)
+                       else
+                         # : _Each[Integer]
+                         args = a_instance.args.zip(@type.args).map do |_var, instance|
+                           if instance
+                             instance.to_s
+                           else
+                             'untyped'
+                           end
+                         end
+                         t = "Object & #{a_instance.name}[#{args.map(&:to_s).join(', ')}]"
+                         Type.new(t).pick(size:)
+                       end
+                     end
         const = ::Object.const_get(@type.name.absolute!.to_s)
-        extend(const)
+        BindCall.extend(@self_type, const)
       end
 
-      def inspect = "#<module #{@type}>"
+      def method_missing(name, *args, **kwargs, &block)
+        @self_type.__send__(name, *args, **kwargs, &block)
+      end
+
+      def respond_to?(name, include_all = false)
+        if BindCall.instance_of?(@self_type, ::BasicObject)
+          BindCall.respond_to?(@self_type, name, include_all)
+        else
+          @self_type.respond_to?(name, include_all)
+        end
+      end
+
+      def inspect = "#<module #{@type} : #{BindCall.class(@self_type)} size=#{@size}>"
       def class = Value::Module
     end
   end

--- a/sig/raap.rbs
+++ b/sig/raap.rbs
@@ -7,7 +7,7 @@ module RaaP
 
   module BindCall
     def self.define_singleton_method: (untyped, Symbol) { (*untyped, **untyped) -> untyped } -> void
-    def self.respond_to?: (untyped, Symbol, ?bool) -> bool
+    def self.respond_to?: (untyped, untyped, ?boolish) -> bool
     def self.instance_of?: (untyped, Module) -> bool
     def self.is_a?: (untyped, Module) -> bool
     def self.extend: (untyped, Module) -> void
@@ -106,7 +106,7 @@ module RaaP
     private
 
     def call: (size: Integer, stats: Stats) -> (Result::Success | Result::Failure | Result::Skip | Result::Exception)
-    def check_return: (receiver_value: untyped, return_value: untyped) -> bool
+    def check_return: (receiver_value: untyped, return_value: untyped) -> ([Symbol] | [Symbol, Exception])
     def return_type: () -> RBS::Types::t
   end
 
@@ -293,8 +293,11 @@ module RaaP
       @type: ::RBS::Types::Interface
       @size: Integer
       @definition: ::RBS::Definition
+      @fixed_return_value: untyped
+      @fixed_block_arguments: Array[untyped]
 
       def initialize: (String | ::RBS::Types::Interface | String, ?size: Integer) -> void
+      def respond_to?: (Symbol, ?boolish) -> bool
       def inspect: () -> String
       def class: () -> class
     end
@@ -305,14 +308,18 @@ module RaaP
       @size: Integer
 
       def initialize: (::RBS::Types::Intersection | String, ?size: Integer) -> void
+      def respond_to?: (Symbol, ?boolish) -> bool
       def inspect: () -> String
       def class: () -> class
     end
 
-    class Module
-      attr_reader type: ::RBS::Types::ClassInstance
+    class Module < BasicObject
+      @type: ::RBS::Types::ClassInstance
+      @size: Integer
+      @self_type: untyped
 
-      def initialize: (::RBS::Types::ClassInstance | String) -> void
+      def initialize: (::RBS::Types::ClassInstance | String, ?size: Integer) -> void
+      def respond_to?: (Symbol, ?boolish) -> bool
       def inspect: () -> String
       def class: () -> class
     end

--- a/sig/shims.rbs
+++ b/sig/shims.rbs
@@ -1,0 +1,4 @@
+module Timeout
+  class ExitException < Exception
+  end
+end

--- a/test/test.rb
+++ b/test/test.rb
@@ -166,4 +166,16 @@ module Test
       self
     end
   end
+
+  module ValueModule
+  end
+
+  module ValueModuleWithBasicObject
+  end
+
+  module ValueModuleWithInterface
+    def each_t(&block)
+      each(&block)
+    end
+  end
 end

--- a/test/test.rbs
+++ b/test/test.rbs
@@ -117,4 +117,14 @@ module Test
     def initialize: (T) -> void
     def nest: (Nested[T]) -> self
   end
+
+  module ValueModule
+  end
+
+  module ValueModuleWithBasicObject : BasicObject
+  end
+
+  module ValueModuleWithInterface[T] : _Each[T]
+    def each_t: () { (T) -> void } -> void
+  end
 end

--- a/test/test_method_type.rb
+++ b/test/test_method_type.rb
@@ -46,7 +46,6 @@ class TestMethodType < Minitest::Test
         Test::Meth.new.arg1(int)
       end
     rescue Minitest::Assertion => e
-      puts e.message
       assert e
     end
   end

--- a/test/test_type.rb
+++ b/test/test_type.rb
@@ -96,11 +96,14 @@ class TestType < Minitest::Test
   end
 
   def test_intersection
-    o = Type.new("_Each[Integer] & Object").pick
+    o = Type.new("Object & _Each[Integer]").pick(size: 10)
+    assert_respond_to o, :each
+
     a = []
     o.each do |i|
       a << i
     end
+    assert_equal 10, a.length
     assert(a.all? { |i| i.instance_of?(Integer) })
 
     assert_equal ["RaaP::Value::Intersection.new('_Each[Integer] & Object', size: 3)"],
@@ -108,11 +111,11 @@ class TestType < Minitest::Test
   end
 
   def test_module
-    assert Kernel === Type.new("Kernel").pick
-    assert Enumerable === Type.new("Enumerable").pick
-    assert Comparable === Type.new("Comparable").pick
-    assert_equal ["RaaP::Value::Module.new('Comparable')"],
-                 Type.new("Comparable").to_symbolic_caller.to_lines
+    assert_respond_to Type.new("Kernel").pick, :object_id # : BasicObject
+    assert_respond_to Type.new("Comparable").pick, :<=>   # : _WithSpaceshipOperator
+    assert_respond_to Type.new("Enumerable").pick, :each  # : _Each[Elem]
+    assert_equal ["RaaP::Value::Module.new('Comparable', size: 13)"],
+                 Type.new("Comparable").to_symbolic_caller(size: 13).to_lines
   end
 
   def test_variable

--- a/test/test_value.rb
+++ b/test/test_value.rb
@@ -49,13 +49,42 @@ class TestValue < Minitest::Test
   end
 
   def test_module
-    mod = Module.new("Comparable")
-    assert mod.object_id
-    assert_respond_to mod, :<=>
-
     assert_raises(TypeError) do
       Module.new("bool")
     end
+
+    mod = Module.new("::Test::ValueModule")
+    assert mod.object_id
+    assert_raises(NoMethodError) do
+      mod.not_defined
+    end
+  end
+
+  def test_module_with_self_type
+    mod = Module.new("::Test::ValueModuleWithBasicObject")
+    assert mod.__id__
+    assert_raises(NoMethodError) do
+      mod.object_id
+    end
+  end
+
+  def test_module_with_interface_and_no_args
+    mod = Module.new("::Test::ValueModuleWithInterface", size: 10)
+    count = 0
+    mod.each_t do
+      count += 1
+    end
+    assert_equal 10, count
+  end
+
+  def test_module_with_interface_and_args
+    mod = Module.new("::Test::ValueModuleWithInterface[Integer]", size: 10)
+    count = 0
+    mod.each_t do |int|
+      count += 1
+      assert_instance_of Integer, int
+    end
+    assert_equal 10, count
   end
 
   def test_top


### PR DESCRIPTION
Example

```rbs
module Enumerable[unchecked out Elem] : _Each[Elem]
```

Implementation image

```rb
enum = RaaP::Type.new("_Each[Integer]").pick # self type is `_Each`
RaaP::BindCall.extend(enum, Enumerable) # can call methods of `Enumerable`
enum.map { |i| i * 2 } #=> [2, -12, 10, -32, 4, -10, -2, 0, 132, -18]
```