### PR TITLE
Refine intersection

### DIFF
--- a/lib/raap/bind_call.rb
+++ b/lib/raap/bind_call.rb
@@ -1,7 +1,7 @@
 module RaaP
   module BindCall
     class << self
-      def define_singleton_method(...) = ::Object.instance_method(:define_singleton_method).bind_call(...)
+      def define_method(...) = ::Module.instance_method(:define_method).bind_call(...)
       def respond_to?(...) = ::Kernel.instance_method(:respond_to?).bind_call(...)
       def instance_of?(...) = ::Kernel.instance_method(:instance_of?).bind_call(...)
       def is_a?(...) = ::Kernel.instance_method(:is_a?).bind_call(...)

--- a/lib/raap/cli.rb
+++ b/lib/raap/cli.rb
@@ -102,9 +102,6 @@ module RaaP
         exit 1
       end
 
-      # Remove comment
-      @argv.delete_if { |arg| arg.empty? || arg.start_with?('#') }
-
       # Search skip tag
       @argv.each do |tag|
         if tag.start_with?('!') && (tag.include?('#') || tag.include?('.'))

--- a/lib/raap/cli.rb
+++ b/lib/raap/cli.rb
@@ -277,9 +277,9 @@ module RaaP
       end
 
       # type_args delegate to self_type
-      type_params_decl.each_with_index do |_, i|
+      type_params_decl.each_with_index do |param, i|
         if rtype.instance_of?(::RBS::Types::ClassInstance)
-          rtype.args[i] = type_args[i] || ::RBS::Types::Bases::Any.new(location: nil)
+          rtype.args[i] = type_args[i] || param.upper_bound || ::RBS::Types::Bases::Any.new(location: nil)
         end
       end
       RaaP.logger.info("## def #{prefix}#{method_name}: #{method_type}")

--- a/lib/raap/cli.rb
+++ b/lib/raap/cli.rb
@@ -109,9 +109,9 @@ module RaaP
       @argv.each do |tag|
         if tag.start_with?('!') && (tag.include?('#') || tag.include?('.'))
           t = tag[1..] or raise
-          at = "::#{t}" unless t.start_with?('::')
-          at or raise
-          @skip << at
+          t = "::#{t}" unless t.start_with?('::')
+          t or raise
+          @skip << t
         end
       end
       @skip.freeze

--- a/lib/raap/cli.rb
+++ b/lib/raap/cli.rb
@@ -326,12 +326,12 @@ module RaaP
         in Result::Skip => s
           print 'S'
           RaaP.logger.debug { "\n```\n#{SymbolicCaller.new(s.symbolic_call).to_lines.join("\n")}\n```" }
-          RaaP.logger.info("Skip: #{s.exception.detailed_message}")
+          RaaP.logger.debug("Skip: #{s.exception.detailed_message}")
           RaaP.logger.debug(s.exception.backtrace.join("\n"))
         in Result::Exception => e
           print 'E'
           RaaP.logger.debug { "\n```\n#{SymbolicCaller.new(e.symbolic_call).to_lines.join("\n")}\n```" }
-          RaaP.logger.info("Exception: #{e.exception.detailed_message}")
+          RaaP.logger.debug("Exception: #{e.exception.detailed_message}")
           RaaP.logger.debug(e.exception.backtrace.join("\n"))
         end
       end

--- a/lib/raap/type_substitution.rb
+++ b/lib/raap/type_substitution.rb
@@ -21,6 +21,9 @@ module RaaP
     end
 
     def method_type_sub(method_type, self_type: nil, instance_type: nil, class_type: nil)
+      self_type = self_type.is_a?(::String) ? RBS.parse_type(self_type) : self_type
+      instance_type = instance_type.is_a?(::String) ? RBS.parse_type(instance_type) : instance_type
+      class_type = class_type.is_a?(::String) ? RBS.parse_type(class_type) : class_type
       sub = build
       ::RBS::MethodType.new(
         type_params: [],

--- a/lib/raap/value/intersection.rb
+++ b/lib/raap/value/intersection.rb
@@ -2,45 +2,38 @@
 
 module RaaP
   module Value
-    class Intersection < BasicObject
-      def initialize(type, size: 3)
-        @type = type.is_a?(::String) ? RBS.parse_type(type) : type
-        unless @type.instance_of?(::RBS::Types::Intersection)
-          ::Kernel.raise ::TypeError, "not an intersection type: #{@type}"
+    module Intersection
+      # Build an object to realize an intersection.
+      def self.new(type, size: 3)
+        type = type.is_a?(::String) ? RBS.parse_type(type) : type
+        unless type.instance_of?(::RBS::Types::Intersection)
+          ::Kernel.raise ::TypeError, "not an intersection type: #{type}"
         end
-        @children = @type.types.map { |t| Type.new(t).pick(size:) }
-        @size = size
-      end
+        instances = type.types.filter_map do |t|
+          t.instance_of?(::RBS::Types::ClassInstance) && Object.const_get(t.name.absolute!.to_s)
+        end
+        instances.uniq!
+        unless instances.count { |c| c.is_a?(::Class) } <= 1
+          raise ArgumentError, "intersection type must have at least one class instance type in `#{instances}`"
+        end
 
-      def inspect
-        "#<intersection @type.to_s=#{@type.to_s.inspect} @size=#{@size.inspect}>"
-      end
+        base = instances.find { |c| c.is_a?(::Class) } || BasicObject
 
-      def class
-        Intersection
-      end
-
-      def method_missing(name, *args, **kwargs, &block)
-        if respond_to?(name)
-          @children.each do |child|
-            if BindCall.respond_to?(child, name)
-              return child.__send__(name, *args, **kwargs, &block)
-            end
+        c = Class.new(base) do
+          instances.select { |i| !i.is_a?(::Class) }.each do |m|
+            include(m)
           end
-          ::Kernel.raise
-        else
-          super
-        end
-      end
 
-      def respond_to?(name, include_all = false)
-        @children.any? do |child|
-          if BindCall.instance_of?(child, ::BasicObject)
-            BindCall.respond_to?(child, name, include_all)
-          else
-            child.respond_to?(name, include_all)
+          interfaces = type.types.select do |t|
+            t.instance_of?(::RBS::Types::Interface)
+          end
+
+          interfaces.each do |interface|
+            Interface.define_method_from_interface(self, interface, size:)
           end
         end
+        type = ::RBS::Types::ClassInstance.new(name: TypeName(base.name), args: [], location: nil)
+        SymbolicCaller.new(Type.call_new_from(c, type, size:)).eval
       end
     end
   end

--- a/sig/raap.rbs
+++ b/sig/raap.rbs
@@ -6,7 +6,7 @@ module RaaP
   def self.logger=: (::Logger) -> void
 
   module BindCall
-    def self.define_singleton_method: (untyped, Symbol) { (*untyped, **untyped) -> untyped } -> void
+    def self.define_method: (untyped, Symbol) { (*untyped, **untyped) -> untyped } -> void
     def self.respond_to?: (untyped, untyped, ?boolish) -> bool
     def self.instance_of?: (untyped, Module) -> bool
     def self.is_a?: (untyped, Module) -> bool
@@ -220,7 +220,7 @@ module RaaP
 
     def initialize: (::Array[::RBS::AST::TypeParam], ::Array[::RBS::Types::t]) -> void
     def build: () -> ::RBS::Substitution
-    def method_type_sub: (::RBS::MethodType, ?self_type: ::RBS::Types::ClassInstance?, ?instance_type: ::RBS::Types::ClassInstance?, ?class_type: ::RBS::Types::ClassSingleton?) -> ::RBS::MethodType
+    def method_type_sub: (::RBS::MethodType, ?self_type: ::RBS::Types::t?, ?instance_type: ::RBS::Types::ClassInstance?, ?class_type: ::RBS::Types::ClassSingleton?) -> ::RBS::MethodType
 
     private
 
@@ -228,7 +228,7 @@ module RaaP
       def map_type: { (untyped) -> untyped } -> untyped
     end
 
-    def sub: (_MapType search, self_type: ::RBS::Types::ClassInstance?, instance_type: ::RBS::Types::ClassInstance?, class_type: ::RBS::Types::ClassSingleton?) -> untyped
+    def sub: (_MapType search, self_type: ::RBS::Types::t?, instance_type: ::RBS::Types::t?, class_type: ::RBS::Types::t?) -> untyped
   end
 
   class Type
@@ -245,6 +245,7 @@ module RaaP
     def self.register: (String) { () [self: instance] -> Sized[untyped] } -> void
     def self.random: () -> Type
     def self.random_without_basic_object: () -> Type
+    def self.call_new_from: (Module, ::RBS::Types::ClassInstance, size: Integer) -> symbolic_call
 
     attr_reader type: ::RBS::Types::t
     attr_reader range: Range[untyped]
@@ -292,9 +293,8 @@ module RaaP
       @type: ::RBS::Types::Interface
       @size: Integer
       @definition: ::RBS::Definition
-      @fixed_return_value: untyped
-      @fixed_block_arguments: Array[untyped]
 
+      def self.define_method_from_interface: (Class base_class, String | ::RBS::Types::Interface type, ?size: Integer) -> void
       def initialize: (String | ::RBS::Types::Interface | String, ?size: Integer) -> void
       def respond_to?: (Symbol, ?boolish) -> bool
       def inspect: () -> String

--- a/test/test.rbs
+++ b/test/test.rbs
@@ -71,6 +71,7 @@ module Test
   end
 
   interface _Interface
+    def lit: () -> :sym
     def void: () -> void
     def selfie: (self) -> self
     def instance: (instance) -> instance

--- a/test/test_value.rb
+++ b/test/test_value.rb
@@ -11,20 +11,18 @@ class TestValue < Minitest::Test
   end
 
   def test_interface
-    assert RaaP::BindCall.instance_of?(Interface.new("Test::_Interface").void, RaaP::Value::Void)
-
-    assert_raises(TypeError) do
-      Interface.new("bool")
-    end
-  end
-
-  def test_interface_with_self_type
-    [Integer, Float, String, Symbol].each do |klass|
-      interface = Interface.new("Test::_Interface", self_type: klass.name)
-      first_return = interface.selfie
-      assert_instance_of klass, first_return
-      assert_equal first_return, interface.selfie
-    end
+    interface = Interface.new("Test::_Interface")
+    assert_equal :sym, interface.lit
+    assert RaaP::BindCall.instance_of?(interface.void, RaaP::Value::Void)
+    assert RaaP::BindCall.is_a?(interface.selfie, RaaP::Value::Interface)
+    assert RaaP::BindCall.instance_of?(interface.instance, Object)
+    assert RaaP::BindCall.instance_of?(interface.klass, Class)
+    # check cache
+    assert_equal :sym, interface.lit
+    assert RaaP::BindCall.instance_of?(interface.void, RaaP::Value::Void)
+    assert RaaP::BindCall.is_a?(interface.selfie, RaaP::Value::Interface)
+    assert RaaP::BindCall.instance_of?(interface.instance, Object)
+    assert RaaP::BindCall.instance_of?(interface.klass, Class)
 
     assert_raises(TypeError) do
       Interface.new("bool")
@@ -46,6 +44,14 @@ class TestValue < Minitest::Test
     assert_raises(NoMethodError) do
       intersection.not_defined
     end
+  end
+
+  def test_math_acos
+    intersection = Intersection.new("Numeric & _ToF", size: 0)
+    # Math methods argument must be Numeric instance
+    assert Math.sin(intersection)
+    assert Math.cos(intersection)
+    assert Math.tan(intersection)
   end
 
   def test_module


### PR DESCRIPTION
The arguments for methods like `Math.sin` must be instances of classes that inherit from `Numeric`.

Therefore, the current implementation using intersection types, which delegates method calls to objects, cannot test `Math` series methods.

This issue can be resolved by creating a temporary class that inherits from the specified class within the Intersection, and treating its instances as instances of the Intersection.