### PR TITLE
Show RBS coverage by default

### DIFF
--- a/lib/raap.rb
+++ b/lib/raap.rb
@@ -23,6 +23,7 @@ module RaaP
 
   autoload :BindCall, "raap/bind_call"
   autoload :CLI, "raap/cli"
+  autoload :Coverage, "raap/coverage"
   autoload :FunctionType, "raap/function_type"
   autoload :MethodProperty, "raap/method_property"
   autoload :MethodType, "raap/method_type"

--- a/lib/raap/cli.rb
+++ b/lib/raap/cli.rb
@@ -12,6 +12,7 @@ module RaaP
       :size_to,
       :size_by,
       :allow_private,
+      :coverage,
       keyword_init: true
     )
 
@@ -44,6 +45,7 @@ module RaaP
         size_from: 0,
         size_to: 99,
         size_by: 1,
+        coverage: true,
         allow_private: false,
       )
       @argv = argv
@@ -82,6 +84,9 @@ module RaaP
         end
         o.on('--preload path', 'Kernel.load path') do |path|
           Kernel.load path
+        end
+        o.on('--[no-]coverage', "Show coverage for RBS (default: #{@option.coverage})") do |arg|
+          @option.coverage = arg
         end
       end.parse!(@argv)
 
@@ -303,6 +308,7 @@ module RaaP
         timeout: @option.timeout,
         allow_private: @option.allow_private,
       )
+      RaaP::Coverage.start(method_type) if @option.coverage
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       stats = prop.run do |called|
         case called
@@ -340,6 +346,9 @@ module RaaP
       end
       end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       puts
+      RaaP::Coverage.show($stdout) if @option.coverage
+      puts
+
       time_diff = end_time - start_time
       time = ", time: #{(time_diff * 1000).round}ms"
       stats_log = "success: #{stats.success}, skip: #{stats.skip}, exception: #{stats.exception}#{time}"

--- a/lib/raap/coverage.rb
+++ b/lib/raap/coverage.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+module RaaP
+  module Coverage
+    class Writer
+      def initialize(method_type, green_locs)
+        @method_type = method_type
+        @green_locs = green_locs
+      end
+
+      def write(io)
+        if (found = @method_type.each_type.find { |type| type.location.nil? })
+          RaaP.logger.info("Cannot show coverage, Because location of #{found} is nil")
+          return
+        end
+
+        location = @method_type.location or raise
+        @cur = location.start_loc
+        @method_type.type.yield_self do |fun|
+          case fun
+          when ::RBS::Types::Function
+            fun.required_positionals.each    { |param| write_param(io, param, :abs) }
+            fun.optional_positionals.each    { |param| write_param(io, param, :opt) }
+            fun.rest_positionals&.yield_self { |param| write_param(io, param, :opt) }
+            fun.trailing_positionals.each    { |param| write_param(io, param, :abs) }
+            fun.required_keywords.each_value { |param| write_param(io, param, :abs) }
+            fun.optional_keywords.each_value { |param| write_param(io, param, :opt) }
+            fun.rest_keywords&.yield_self    { |param| write_param(io, param, :opt) }
+            # when ::RBS::Types::UntypedFunction
+          end
+        end
+        @method_type.block&.yield_self do |b|
+          b.type.each_param { |param| write_param(io, param, :opt) }
+          write_type(io, b.type.return_type, b.type.return_type.location, :abs)
+          # write_type(io, b.self_type) if b.self_type
+        end
+        write_type(io, @method_type.type.return_type, @method_type.type.return_type.location, :abs)
+
+        io.write(slice_by_loc(@cur, location.end_loc))
+        io.puts
+      end
+
+      private
+
+      def slice_by_loc(a, b)
+        location = @method_type.location or raise
+        mloc = location.start_loc
+        lines = location.source.lines
+        start_pos = lines.take(a[0] - mloc[0]).inject(0) { |r, line| r + line.length } + (a[1])
+        start_pos -= mloc[1] if a[0] == mloc[0]
+        end_pos = lines.take(b[0] - mloc[0]).inject(0) { |r, line| r + line.length } + (b[1])
+        end_pos -= mloc[1] if b[0] == mloc[0]
+        location.source[start_pos...end_pos] or raise
+      end
+
+      def write_param(io, param, accuracy)
+        param.location or raise
+        write_type(io, param.type, param.location, accuracy)
+      end
+
+      def write_type(io, type, location, accuracy)
+        io.write(slice_by_loc(@cur, location.start_loc))
+        @cur = location.start_loc
+        case type
+        when ::RBS::Types::Tuple, ::RBS::Types::Union
+          type.types.each do |t|
+            t.location or raise
+            io.write(slice_by_loc(@cur, t.location.start_loc))
+            @cur = t.location.end_loc
+            write_type(io, t, t.location, accuracy)
+          end
+        when ::RBS::Types::Optional
+          type.type.location or raise
+          sliced_loc = type.location.dup
+          sliced_loc.tap do |s|
+            s = __skip__ = s
+            # FIXME: Hackish, cut 1 character from back.
+            s.source
+            s.instance_eval { @source = @source[0...-1] }
+            s.end_loc
+            s.instance_eval { @end_loc = [@end_loc[0], @end_loc[1] - 1] }
+          end
+          write_type(io, type.type, sliced_loc, accuracy)
+          if @green_locs.include?([location.end_loc.dup.tap { _1[1] -= 1 }, location.end_loc])
+            io.write(green('?'))
+          else
+            io.write(red('?'))
+          end
+          @cur = location.end_loc
+        when ::RBS::Types::Variable
+          case accuracy
+          when :abs
+            io.write(green(type.name.to_s))
+          when :opt
+            # Variables are substed so raap don't know if they've been used.
+            io.write(yellow(type.name.to_s))
+          end
+          @cur = location.end_loc
+        else
+          if @green_locs.include?([location.start_loc, location.end_loc])
+            io.write(green(location.source))
+          else
+            io.write(red(location.source))
+          end
+          @cur = location.end_loc
+        end
+      end
+
+      def green(str) = "\e[32m#{str}\e[0m"
+      def red(str) = "\e[1;4;41m#{str}\e[0m"
+      def yellow(str) = "\e[93m#{str}\e[0m"
+    end
+
+    Log = Data.define(:name, :locs)
+
+    class << self
+      def start(method_type)
+        @logs = []
+        @method_type = method_type
+      end
+
+      def running?
+        !!@logs
+      end
+
+      def log(name:, locs:)
+        return unless running?
+
+        @logs << Log.new(name: name, locs: locs)
+      end
+
+      def logs
+        @logs
+      end
+
+      def show(io)
+        writer = Writer.new(@method_type, green_locs)
+        writer.write(io)
+      end
+
+      private
+
+      def green_locs
+        @logs.select { |log| log.name == @method_type.location.buffer.name }
+             .map(&:locs)
+             .sort
+             .to_set
+      end
+    end
+  end
+end

--- a/lib/raap/coverage.rb
+++ b/lib/raap/coverage.rb
@@ -117,6 +117,9 @@ module RaaP
       def start(method_type)
         @logs = []
         @method_type = method_type
+        if @method_type.location.nil?
+          @logs = nil
+        end
       end
 
       def running?
@@ -134,6 +137,8 @@ module RaaP
       end
 
       def show(io)
+        return unless running?
+
         writer = Writer.new(@method_type, green_locs)
         writer.write(io)
       end

--- a/lib/raap/value/interface.rb
+++ b/lib/raap/value/interface.rb
@@ -30,16 +30,13 @@ module RaaP
                                               Type.new(subed_method_type.type.return_type).pick(size: size)
                                             end
               # @type var b: Proc?
-              if b
+              if b && subed_method_type.block && subed_method_type.block.type.is_a?(::RBS::Types::Function)
                 @fixed_block_arguments ||= {}
-                @fixed_block_arguments[name] ||= if subed_method_type.block
-                                                   size.times.map do
-                                                     FunctionType.new(subed_method_type.block.type)
-                                                                 .pick_arguments(size: size)
-                                                   end
-                                                 else
-                                                   []
-                                                 end
+                @fixed_block_arguments[name] ||= size.times.map do
+                  FunctionType.new(subed_method_type.block.type)
+                              .pick_arguments(size: size)
+                end
+
                 @fixed_block_arguments[name].each do |a, kw|
                   b.call(*a, **kw)
                 end

--- a/sig/raap.rbs
+++ b/sig/raap.rbs
@@ -19,15 +19,15 @@ module RaaP
 
   class CLI
     class Option < ::Struct[untyped]
-      def self.new: (?dirs: ::Array[String], ?requires: ::Array[String], ?libraries: ::Array[String], ?timeout: (Integer | Float | nil), ?size_from: ::Integer, ?size_to: ::Integer, ?size_by: ::Integer, ?allow_private: bool) -> instance
+      def self.new: (?dirs: ::Array[String], ?requires: ::Array[String], ?libraries: ::Array[String], ?timeout: (Integer | Float | nil), ?size_from: ::Integer, ?size_to: ::Integer, ?size_by: ::Integer, ?allow_private: bool, ?coverage: bool) -> instance
 
-      def self.[]: (?dirs: ::Array[String], ?requires: ::Array[String], ?libraries: ::Array[String], ?timeout: (Integer | Float | nil), ?size_from: ::Integer, ?size_to: ::Integer, ?size_by: ::Integer, ?allow_private: bool) -> instance
+      def self.[]: (?dirs: ::Array[String], ?requires: ::Array[String], ?libraries: ::Array[String], ?timeout: (Integer | Float | nil), ?size_from: ::Integer, ?size_to: ::Integer, ?size_by: ::Integer, ?allow_private: bool, ?coverage: bool) -> instance
 
       def self.keyword_init?: () -> true
 
-      def self.members: () -> [ :dirs, :requires, :library, :timeout, :size_from, :size_to, :size_by, :allow_private]
+      def self.members: () -> [ :dirs, :requires, :library, :timeout, :size_from, :size_to, :size_by, :allow_private, :coverage]
 
-      def members: () -> [ :dirs, :requires, :library, :timeout, :size_from, :size_to, :size_by, :allow_private]
+      def members: () -> [ :dirs, :requires, :library, :timeout, :size_from, :size_to, :size_by, :allow_private, :coverage]
 
       attr_accessor dirs: ::Array[String]
 
@@ -44,6 +44,8 @@ module RaaP
       attr_accessor size_by: ::Integer
 
       attr_accessor allow_private: bool
+
+      attr_accessor coverage: bool
     end
 
     type property_result = [Integer, Symbol, ::RBS::MethodType, StringIO?]
@@ -71,6 +73,45 @@ module RaaP
     def report: () -> Integer
   end
 
+  module Coverage
+    type locs = [::RBS::Buffer::loc, ::RBS::Buffer::loc]
+    type accuracy = :abs | :opt
+    class Writer
+      @method_type: ::RBS::MethodType
+      @green_locs: ::Set[locs]
+      @cur: ::RBS::Buffer::loc
+
+      def initialize: (::RBS::MethodType, Set[locs]) -> void
+      def write: (IO) -> void
+
+      private
+
+      def slice_by_loc: (::RBS::Buffer::loc, ::RBS::Buffer::loc) -> String
+      def write_param: (IO, ::RBS::Types::Function::Param, accuracy) -> void
+      def write_type: (IO, ::RBS::Types::t, untyped, accuracy) -> void
+      def green: (String) -> String
+      def red: (String) -> String
+      def yellow: (String) -> String
+    end
+
+    class Log
+      attr_reader name: String
+      attr_reader locs: [::RBS::Buffer::loc, ::RBS::Buffer::loc]
+
+      def initialize: (name: String, locs: [::RBS::Buffer::loc, ::RBS::Buffer::loc]) -> void
+    end
+
+    def self.start: (::RBS::MethodType) -> void
+    def self.running?: () -> bool
+    def self.log: (name: String, locs: [::RBS::Buffer::loc, ::RBS::Buffer::loc]) -> void
+    def self.logs: () -> Array[Log]
+    def self.show: (IO) -> void
+
+    private
+
+    def self.green_locs: () -> Set[[::RBS::Buffer::loc, ::RBS::Buffer::loc]]
+  end
+
   class FunctionType
     @fun: ::RBS::Types::Function
 
@@ -83,6 +124,7 @@ module RaaP
     def to_symbolic_call_recursive: (untyped, size: Integer) -> untyped
     def build_args_type: () -> Array[Type]
     def build_kwargs_type: () -> Hash[Symbol, Type]
+    def build_type_with_coverage: (::RBS::Types::Function::Param) -> Type
   end
 
   class MethodProperty
@@ -108,10 +150,13 @@ module RaaP
     def call: (size: Integer, stats: Stats) -> (Result::Success | Result::Failure | Result::Skip | Result::Exception)
     def check_return: (receiver_value: untyped, return_value: untyped) -> ([Symbol] | [Symbol, Exception])
     def return_type: () -> RBS::Types::t
+    def original_return_type: () -> RBS::Types::t
+    def coverage: (untyped, RBS::Types::t, RBS::Test::TypeCheck) -> void
   end
 
   class MethodType
     attr_reader rbs: ::RBS::MethodType
+    attr_reader original_rbs: ::RBS::MethodType
     @fun_type: FunctionType
 
     def initialize: (::RBS::MethodType | String method, ?type_params_decl: Array[untyped], ?type_args: Array[untyped], ?self_type: ::RBS::Types::ClassInstance?, ?instance_type: ::RBS::Types::ClassInstance?, ?class_type: ::RBS::Types::ClassSingleton?) -> void

--- a/test/test.rb
+++ b/test/test.rb
@@ -227,4 +227,11 @@ module Test
       raise TestException
     end
   end
+
+  class Coverage
+    def one_line(int, sym) = [int, sym]
+    def two_lines(a:, b: nil, **rk) = a
+    def three_lines = [:a, :c].sample
+    def block = yield(1)
+  end
 end

--- a/test/test.rbs
+++ b/test/test.rbs
@@ -163,4 +163,17 @@ module Test
   class ExceptionWithBot
     def exception: () -> bot
   end
+
+  class Coverage
+    def one_line: (Integer, Symbol) -> [Integer, Symbol]
+    def two_lines:
+      [T] (a: Symbol,
+        ?b: Integer?,
+          **T) -> void
+    def three_lines: () -> (:a |
+    :b
+                      | :c)
+
+    def block: () { (::Integer x) -> 1 } -> 1
+  end
 end

--- a/test/test_coverage.rb
+++ b/test/test_coverage.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestCoverage < Minitest::Test
+  def test_coverage
+    assert_equal 0, RaaP::CLI.new([
+      "--log-level", "info",
+      "--timeout", "0",
+      "--size-to", "10",
+      "--coverage",
+      "Test::Coverage",
+    ]).load.run
+  end
+end

--- a/test/test_exe.rb
+++ b/test/test_exe.rb
@@ -1,40 +1,14 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "test"
 
 class TestExe < Minitest::Test
-  RaaP::Type.register("::Test::List") do
-    sized do |size|
-      list = [:call, Test::List, :new, [], {}, nil]
-      arg = type.args[0] ? RaaP::Type.new(type.args[0]) : RaaP::Type.random
-      size.times.inject(list) do |r, i|
-        [:call, r, :add, [arg.pick(size: i / 2)], {}, nil]
-      end
-    end
-  end
-
   def capture
     orig = $stdout
     $stdout = StringIO.new
     yield $stdout
   ensure
     $stdout = orig
-  end
-
-  def test_exe_with_search
-    assert_equal 0, RaaP::CLI.new([
-      "--log-level", "info",
-      "--timeout", "0.5",
-      "--size-by", "5",
-      "Test::*",
-      "!Test::Property#alias",
-      "!Test::List",
-      "!Test::SkipPrefix#should_skip",
-      "!Test::NameErrorLogging",
-      "!Test::TypeErrorIsFail",
-      "!Test::ExceptionWithBot",
-    ]).load.run
   end
 
   def test_skip_by_name_error
@@ -115,7 +89,7 @@ class TestExe < Minitest::Test
   def test_exe_without_args
     assert_equal 0, RaaP::CLI.new([
       "--log-level", "info",
-      "--timeout", "1",
+      "--timeout", "0",
       "--size-by", "20",
       "Test::List",
     ]).load.run
@@ -124,7 +98,7 @@ class TestExe < Minitest::Test
   def test_exe_with_args
     assert_equal 0, RaaP::CLI.new([
       "--log-level", "info",
-      "--timeout", "1",
+      "--timeout", "0",
       "--size-to", "20",
       "Test::List[Integer]",
     ]).load.run

--- a/test/test_exe_search.rb
+++ b/test/test_exe_search.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestExeSearch < Minitest::Test
+  def test_exe_with_search
+    assert_equal 0, RaaP::CLI.new([
+      "--log-level", "info",
+      "--timeout", "0.5",
+      "--size-by", "5",
+      "Test::*",
+      "!Test::Property#alias",
+      "!Test::List",
+      "!Test::SkipPrefix#should_skip",
+      "!Test::NameErrorLogging",
+      "!Test::TypeErrorIsFail",
+      "!Test::ExceptionWithBot",
+      "!Test::Coverage",
+    ]).load.run
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,3 +49,13 @@ require "raap/minitest"
 require_relative './test'
 
 RaaP::RBS.loader.add(path: Pathname('test/test.rbs'))
+
+RaaP::Type.register("::Test::List") do
+  sized do |size|
+    list = [:call, Test::List, :new, [], {}, nil]
+    arg = type.args[0] ? RaaP::Type.new(type.args[0]) : RaaP::Type.random
+    size.times.inject(list) do |r, i|
+      [:call, r, :add, [arg.pick(size: i / 2)], {}, nil]
+    end
+  end
+end

--- a/test/test_method_type.rb
+++ b/test/test_method_type.rb
@@ -94,7 +94,7 @@ class TestMethodType < Minitest::Test
   def test_pick_arguments_with_type_params
     args, _, _ = MethodType.new("[T] (T) -> T").pick_arguments
     assert args.length == 1
-    assert args.first.instance_of?(RaaP::Value::Variable)
+    # assert args.first.instance_of?(RaaP::Value::Variable)
   end
 
   def test_pick_arguments_with_type_params_and_bound

--- a/test/test_method_type.rb
+++ b/test/test_method_type.rb
@@ -94,7 +94,7 @@ class TestMethodType < Minitest::Test
   def test_pick_arguments_with_type_params
     args, _, _ = MethodType.new("[T] (T) -> T").pick_arguments
     assert args.length == 1
-    assert_raises(NoMethodError) { args.first.to_s }
+    assert args.first.instance_of?(RaaP::Value::Variable)
   end
 
   def test_pick_arguments_with_type_params_and_bound


### PR DESCRIPTION
Example of `Symbol#downcase`

```
$ bundle exec raap --size-to 1 '::Symbol#downcase'
```
<img width="591" alt="image" src="https://github.com/ksss/raap/assets/935310/40147fcb-c4aa-4b8a-80dd-132b0dec79c2">

🟩 The green type means that the value was actually generated and used at the time of the method call.
🟥 The red type means that the value was never generated and was not used at the time of the method call.

In the image example, `:ascii` and `:lithuanian` are used, but `:fold` and `:turkic` are never used.