### PR TITLE
Should be based on Object instead of BasicObject for Variable, Interface and Intersection.

### DIFF
--- a/lib/raap/value/interface.rb
+++ b/lib/raap/value/interface.rb
@@ -2,9 +2,9 @@
 
 module RaaP
   module Value
-    class Interface < BasicObject
+    class Interface
       class << self
-        def define_method_from_interface(base_class, type, size: 3)
+        def define_method_from_interface(base_mod, type, size: 3)
           type = type.is_a?(::String) ? RBS.parse_type(type) : type
           unless type.instance_of?(::RBS::Types::Interface)
             ::Kernel.raise ::TypeError, "not an interface type: #{type}"
@@ -22,7 +22,7 @@ module RaaP
             ts = TypeSubstitution.new(type_params, type.args)
             subed_method_type = ts.method_type_sub(method_type, self_type: self_type, instance_type: instance_type, class_type: class_type)
 
-            BindCall.define_method(base_class, name) do |*_, &b|
+            BindCall.define_method(base_mod, name) do |*_, &b|
               @fixed_return_value ||= {}
               @fixed_return_value[name] ||= if self_type == subed_method_type.type.return_type
                                               self
@@ -63,14 +63,6 @@ module RaaP
         end
         @definition = RBS.builder.build_interface(@type.name.absolute!)
         @size = size
-      end
-
-      def respond_to?(name, _include_all = false)
-        @definition.methods.has_key?(name.to_sym)
-      end
-
-      def class
-        Interface
       end
 
       def inspect

--- a/lib/raap/value/intersection.rb
+++ b/lib/raap/value/intersection.rb
@@ -17,19 +17,18 @@ module RaaP
           raise ArgumentError, "intersection type must have at least one class instance type in `#{instances}`"
         end
 
-        base = instances.find { |c| c.is_a?(::Class) } || BasicObject
+        base = instances.find { |c| c.is_a?(::Class) } || Object
 
         c = Class.new(base) do
           instances.select { |i| !i.is_a?(::Class) }.each do |m|
             include(m)
           end
 
-          interfaces = type.types.select do |t|
-            t.instance_of?(::RBS::Types::Interface)
-          end
-
-          interfaces.each do |interface|
-            Interface.define_method_from_interface(self, interface, size: size)
+          type.types.each do |t|
+            case t
+            when ::RBS::Types::Interface
+              Interface.define_method_from_interface(self, t, size: size)
+            end
           end
         end
         type = ::RBS::Types::ClassInstance.new(name: TypeName(base.name), args: [], location: nil)

--- a/lib/raap/value/variable.rb
+++ b/lib/raap/value/variable.rb
@@ -2,7 +2,7 @@
 
 module RaaP
   module Value
-    class Variable < BasicObject
+    class Variable
       attr_reader :type
 
       def initialize(type)

--- a/sig/raap.rbs
+++ b/sig/raap.rbs
@@ -330,19 +330,19 @@ module RaaP
       def class: () -> class
     end
 
-    class Interface < BasicObject
+    class Interface
       @type: ::RBS::Types::Interface
       @size: Integer
       @definition: ::RBS::Definition
 
-      def self.define_method_from_interface: (Class base_class, String | ::RBS::Types::Interface type, ?size: Integer) -> void
+      def self.define_method_from_interface: (::Module base_class, String | ::RBS::Types::Interface type, ?size: Integer) -> void
       def initialize: (String | ::RBS::Types::Interface | String, ?size: Integer) -> void
       def respond_to?: (Symbol, ?boolish) -> bool
       def inspect: () -> String
       def class: () -> class
     end
 
-    class Intersection < BasicObject
+    module Intersection
       @type: ::RBS::Types::Intersection
       @children: Array[Type]
       @size: Integer
@@ -369,7 +369,7 @@ module RaaP
       def class: () -> class
     end
 
-    class Variable < BasicObject
+    class Variable
       attr_reader type: ::RBS::Types::Variable
 
       def initialize: (::RBS::Types::Variable | String | Symbol) -> void

--- a/test/test_value.rb
+++ b/test/test_value.rb
@@ -12,9 +12,12 @@ class TestValue < Minitest::Test
 
   def test_interface
     interface = Interface.new("Test::_Interface")
+
+    assert interface.respond_to?(:object_id)
+
     assert interface.respond_to?(:lit)
     assert interface.inspect
-    assert_equal RaaP::Value::Interface, interface.class
+    assert interface.is_a?(RaaP::Value::Interface)
 
     assert_equal :sym, interface.lit
     assert RaaP::BindCall.instance_of?(interface.void, RaaP::Value::Void)
@@ -34,6 +37,9 @@ class TestValue < Minitest::Test
   end
 
   def test_intersection
+    intersection = Intersection.new("_ToF & _ToI", size: 10)
+    assert intersection.object_id
+
     intersection = Intersection.new("Object & _Each[Integer]", size: 10)
     assert intersection.object_id
     intersection.each do |int|
@@ -107,6 +113,7 @@ class TestValue < Minitest::Test
   def test_variable
     assert_equal "#<var T>", Variable.new("T").inspect
     assert_equal Variable, Variable.new("T").class
+    assert Variable.new("T").object_id
     assert_equal ::RBS::Types::Variable.new(name: :T, location: nil), Variable.new(:T).type
     assert_raises TypeError do
       Variable.new(1)


### PR DESCRIPTION
The current BasicObject-based implementation requires the `Object &` on many types. It would be more practical to base the implementation on Objects.