### PR TITLE
Type-checking block arguments

### DIFF
--- a/lib/raap/coverage.rb
+++ b/lib/raap/coverage.rb
@@ -25,7 +25,7 @@ module RaaP
               RaaP.logger.warn("No location information for `#{phantom_member}`")
               return
             end
-            write_type(io, "return", phantom_member.type, :abs)
+            write_type(io, "return", phantom_member.type)
             io.write(slice(@cur, @cur...phantom_member.location.end_pos))
           else
             RaaP.logger.error("#{phantom_member.class} is not supported")
@@ -37,22 +37,22 @@ module RaaP
           phantom_method_type.type.yield_self do |fun|
             case fun
             when ::RBS::Types::Function
-              fun.required_positionals.each_with_index { |param, i| write_param(io, "req_#{i}", param, :abs) }
-              fun.optional_positionals.each_with_index { |param, i| write_param(io, "opt_#{i}", param, :opt) }
-              fun.rest_positionals&.yield_self         { |param| write_param(io, "rest", param, :opt) }
-              fun.trailing_positionals.each_with_index { |param, i| write_param(io, "trail_#{i}", param, :abs) }
-              fun.required_keywords.each               { |key, param| write_param(io, "keyreq_#{key}", param, :abs) }
-              fun.optional_keywords.each               { |key, param| write_param(io, "key_#{key}", param, :opt) }
-              fun.rest_keywords&.yield_self            { |param| write_param(io, "keyrest", param, :opt) }
+              fun.required_positionals.each_with_index { |param, i| write_param(io, "req_#{i}", param) }
+              fun.optional_positionals.each_with_index { |param, i| write_param(io, "opt_#{i}", param) }
+              fun.rest_positionals&.yield_self         { |param| write_param(io, "rest", param) }
+              fun.trailing_positionals.each_with_index { |param, i| write_param(io, "trail_#{i}", param) }
+              fun.required_keywords.each               { |key, param| write_param(io, "keyreq_#{key}", param) }
+              fun.optional_keywords.each               { |key, param| write_param(io, "key_#{key}", param) }
+              fun.rest_keywords&.yield_self            { |param| write_param(io, "keyrest", param) }
               # when ::RBS::Types::UntypedFunction
             end
           end
 
           phantom_method_type.block&.yield_self do |b|
-            b.type.each_param.with_index { |param, i| write_param(io, "block_param_#{i}", param, :opt) }
-            write_type(io, "block_return", b.type.return_type, :abs)
+            b.type.each_param.with_index { |param, i| write_param(io, "block_param_#{i}", param) }
+            write_type(io, "block_return", b.type.return_type)
           end
-          write_type(io, "return", phantom_method_type.type.return_type, :abs)
+          write_type(io, "return", phantom_method_type.type.return_type)
           raise unless phantom_method_type.location
 
           io.write(slice(@cur, @cur...phantom_method_type.location.end_pos))
@@ -70,11 +70,11 @@ module RaaP
         ml.source[start, range.end - range.begin] or raise
       end
 
-      def write_param(io, position, param, accuracy)
-        write_type(io, position, param.type, accuracy)
+      def write_param(io, position, param)
+        write_type(io, position, param.type)
       end
 
-      def write_type(io, position, type, accuracy)
+      def write_type(io, position, type)
         unless type.location
           RaaP.logger.warn("No location information for `#{type}`")
           return
@@ -88,29 +88,18 @@ module RaaP
             t.location or raise
             io.write(slice(@cur, @cur...t.location.start_pos)) # ( or [
             @cur = t.location.start_pos
-            write_type(io, "#{position}_#{name}_#{i}", t, accuracy)
+            write_type(io, "#{position}_#{name}_#{i}", t)
           end
         when ::RBS::Types::Optional
           raise unless type.location
 
-          write_type(io, "#{position}_optional_left", type.type, accuracy)
+          write_type(io, "#{position}_optional_left", type.type)
           io.write(slice(@cur, @cur...(type.location.end_pos - 1)))
           @cur = type.location.end_pos - 1
           if @cov.include?("#{position}_optional_right".to_sym)
             io.write(green('?'))
           else
             io.write(red('?'))
-          end
-          raise unless type.location
-
-          @cur = type.location.end_pos
-        when ::RBS::Types::Variable
-          case accuracy
-          when :abs
-            io.write(green(type.name.to_s))
-          when :opt
-            # Variables are substed so raap don't know if they've been used.
-            io.write(yellow(type.name.to_s))
           end
           raise unless type.location
 
@@ -129,7 +118,6 @@ module RaaP
 
       def green(str) = "\e[32m#{str}\e[0m"
       def red(str) = "\e[1;4;41m#{str}\e[0m"
-      def yellow(str) = "\e[93m#{str}\e[0m"
     end
 
     class << self

--- a/lib/raap/method_type.rb
+++ b/lib/raap/method_type.rb
@@ -2,7 +2,7 @@
 
 module RaaP
   class MethodType
-    attr_reader :rbs, :original_rbs
+    attr_reader :rbs
 
     def initialize(method, type_params_decl: [], type_args: [], self_type: nil, instance_type: nil, class_type: nil)
       rbs =
@@ -19,11 +19,17 @@ module RaaP
 
       params = (type_params_decl + rbs.type_params).uniq
       ts = TypeSubstitution.new(params, type_args)
-
-      @original_rbs = rbs
       @rbs = ts.method_type_sub(rbs, self_type: self_type, instance_type: instance_type, class_type: class_type)
       function_or_untypedfunction = __skip__ = @rbs.type
       @fun_type = FunctionType.new(function_or_untypedfunction)
+      @type_check = ::RBS::Test::TypeCheck.new(
+        self_class: (_ = self_type),
+        instance_class: (_ = instance_type),
+        class_class: (_ = class_type),
+        builder: RBS.builder,
+        sample_size: 100,
+        unchecked_classes: []
+      )
     end
 
     def pick_arguments(size: 10)
@@ -42,28 +48,63 @@ module RaaP
       return nil if block.nil?
       return nil if (block.required == false) && [true, false].sample
 
-      fixed_return_value = Type.new(block.type.return_type).pick(size: size)
-      Proc.new do
-        block.type.each_param.with_index do |_param, i|
-          Coverage.log("block_param_#{i}")
+      args_name = []
+      args_source = []
+      resource = [*'a'..'z']
+      case fun = block.type
+      when ::RBS::Types::Function
+        # FIXME: Support keyword types
+        fun.required_positionals.each do
+          resource.shift.tap do |name|
+            args_name << name
+            args_source << name
+          end
         end
-
-        Coverage.new_type_with_log("block_return", block.type.return_type)
-        fixed_return_value
+        fun.optional_positionals.each do |param|
+          resource.shift.tap do |name|
+            # FIXME: Support without literal type
+            default = Type.new(param.type).pick(size: size)
+            args_name << name
+            args_source << "#{name} = #{default}"
+          end
+        end
+        fun.rest_positionals&.yield_self do |_|
+          resource.shift.tap do |name|
+            args_name << "*#{name}"
+            args_source << "*#{name}"
+          end
+        end
+        fun.trailing_positionals.each do
+          resource.shift.tap do |name|
+            args_name << name
+            args_source << name
+          end
+        end
       end
+      # Hack: Use local variable in eval
+      fixed_return_value = Type.new(block.type.return_type).pick(size: size)
+      _ = fixed_return_value
+      type_check = @type_check
+      _ = type_check
+      eval(<<~RUBY) # rubocop:disable Security/Eval
+        -> (#{args_source.join(', ')}) do
+          i = 0
+          type_check.zip_args([#{args_name.join(', ')}], block.type) do |val, param|
+            unless type_check.value(val, param.type)
+              raise TypeError, "block argument type mismatch: expected `(\#{fun.param_to_s})`, got \#{BindCall.inspect([#{args_name.join(', ')}])}"
+            end
+
+            Coverage.log_with_type("block_param_\#{i}", param.type)
+            i += 1
+          end
+          Coverage.log_with_type("block_return", block.type.return_type)
+          fixed_return_value
+        end
+      RUBY
     end
 
     def check_return(return_value)
-      untyped = __skip__ = nil
-      type_check = ::RBS::Test::TypeCheck.new(
-        self_class: untyped,     # cannot support `self`
-        instance_class: untyped, # cannot support `instance`
-        class_class: untyped,    # cannot support `class`
-        builder: RBS.builder,
-        sample_size: 100,
-        unchecked_classes: []
-      )
-      type_check.value(return_value, rbs.type.return_type)
+      @type_check.value(return_value, rbs.type.return_type)
     end
   end
 end

--- a/sig/raap.rbs
+++ b/sig/raap.rbs
@@ -104,6 +104,8 @@ module RaaP
     def self.cov: () -> Set[Symbol]
     def self.show: (IO) -> void
     def self.new_type_with_log: (String, ::RBS::Types::t) -> Type
+    def self.log_with_type: (String, ::RBS::Types::t) -> nil
+                          | (String, ::RBS::Types::t) ?{ (::RBS::Types::t) -> Type } -> Type
   end
 
   class FunctionType
@@ -151,8 +153,8 @@ module RaaP
 
   class MethodType
     attr_reader rbs: ::RBS::MethodType
-    attr_reader original_rbs: ::RBS::MethodType
     @fun_type: FunctionType
+    @type_check: ::RBS::Test::TypeCheck
 
     def initialize: (::RBS::MethodType | String method, ?type_params_decl: Array[untyped], ?type_args: Array[untyped], ?self_type: ::RBS::Types::ClassInstance?, ?instance_type: ::RBS::Types::ClassInstance?, ?class_type: ::RBS::Types::ClassSingleton?) -> void
     def pick_arguments: (?size: Integer) -> [Array[untyped], Hash[Symbol, untyped], ::Proc?]

--- a/sig/raap.rbs
+++ b/sig/raap.rbs
@@ -75,7 +75,6 @@ module RaaP
 
   module Coverage
     type locs = [::RBS::Buffer::loc, ::RBS::Buffer::loc]
-    type accuracy = :abs | :opt
     class Writer
       @method_type: ::RBS::MethodType
       @cov: ::Set[Symbol]
@@ -88,11 +87,10 @@ module RaaP
 
       def method_type_location: () -> ::RBS::Location[untyped, untyped]
       def slice: (Integer, Range[Integer]) -> String
-      def write_param: (IO, String, ::RBS::Types::Function::Param, accuracy) -> void
-      def write_type: (IO, String, ::RBS::Types::t, accuracy) -> void
+      def write_param: (IO, String, ::RBS::Types::Function::Param) -> void
+      def write_type: (IO, String, ::RBS::Types::t) -> void
       def green: (String) -> String
       def red: (String) -> String
-      def yellow: (String) -> String
     end
 
     self.@cov: Set[Symbol]?

--- a/test/test.rb
+++ b/test/test.rb
@@ -242,4 +242,10 @@ module Test
     def all_variables(*) = 1
     def singleton = Test::Coverage
   end
+
+  class BlockArgsCheck
+    def different_type
+      yield 'zzz'
+    end
+  end
 end

--- a/test/test.rbs
+++ b/test/test.rbs
@@ -179,4 +179,8 @@ module Test
     attr_reader a: A? | Object
     def singleton: () -> singleton(Coverage)
   end
+
+  class BlockArgsCheck
+    def different_type: () { (Integer) -> void } -> void
+  end
 end

--- a/test/test_exe.rb
+++ b/test/test_exe.rb
@@ -103,4 +103,10 @@ class TestExe < Minitest::Test
       "Test::List[Integer]",
     ]).load.run
   end
+
+  def test_exe_when_fail_block_params_type_mismatch
+    assert_equal 1, RaaP::CLI.new([
+      "Test::BlockArgsCheck#different_type",
+    ]).load.run
+  end
 end

--- a/test/test_exe_search.rb
+++ b/test/test_exe_search.rb
@@ -16,6 +16,7 @@ class TestExeSearch < Minitest::Test
       "!Test::TypeErrorIsFail",
       "!Test::ExceptionWithBot",
       "!Test::Coverage",
+      "!Test::BlockArgsCheck",
     ]).load.run
   end
 end


### PR DESCRIPTION
Block arguments are values generated by the method.
It is similar to an argument.
Therefore, they can be subject to type checking.