### PR TITLE
Avoid ArgumentError no keywords accepted

### DIFF
--- a/lib/raap/symbolic_caller.rb
+++ b/lib/raap/symbolic_caller.rb
@@ -148,9 +148,17 @@ module RaaP
     def eval_one(symbolic_call)
       symbolic_call => [:call, receiver_value, method_name, args, kwargs, block]
       if @allow_private
-        receiver_value.__send__(method_name, *args, **kwargs, &block)
+        if kwargs.empty?
+          receiver_value.__send__(method_name, *args, &block)
+        else
+          receiver_value.__send__(method_name, *args, **kwargs, &block)
+        end
       else
-        BindCall.public_send(receiver_value, method_name, *args, **kwargs, &block)
+        if kwargs.empty?
+          BindCall.public_send(receiver_value, method_name, *args, &block)
+        else
+          BindCall.public_send(receiver_value, method_name, *args, **kwargs, &block)
+        end
       end
     end
 

--- a/test/test.rb
+++ b/test/test.rb
@@ -252,4 +252,9 @@ module Test
       yield 'zzz'
     end
   end
+
+  class NoKey
+    def a(**nil) = nil
+    def b(*, **nil) = nil
+  end
 end

--- a/test/test_symbolic_caller.rb
+++ b/test/test_symbolic_caller.rb
@@ -34,6 +34,20 @@ class TestSymbolicCaller < Minitest::Test
     assert_raises(NoMethodError) { SymbolicCaller.new(sc).eval }
   end
 
+  def test_nokey_argument
+    [true, false].each do |allow_private|
+      [:a, :b].each do |method_name|
+        sc = SymbolicCaller.new(
+          [:call,
+           [:call, Test::NoKey, :new, [], {}, nil],
+           method_name, [], {}, nil],
+          allow_private: allow_private
+        )
+        assert_nil sc.eval
+      end
+    end
+  end
+
   def test_to_lines
     sc = SymbolicCaller.new([
       :call,


### PR DESCRIPTION
See also https://bugs.ruby-lang.org/issues/20570