### PR TITLE
Round up the lowest version of the RBS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     raap (1.2.0)
-      rbs (~> 3.0)
+      rbs (~> 3.9.0)
       timeout (~> 0.4)
 
 GEM

--- a/raap.gemspec
+++ b/raap.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rbs", "~> 3.0"
+  spec.add_dependency "rbs", "~> 3.9.0"
   spec.add_dependency "timeout", "~> 0.4"
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
`RBS::Definition::Method::TypeDef#each_annotation` was introduced in rbs v3.9